### PR TITLE
Adding Cephfs QNA files

### DIFF
--- a/knowledge/technical_manual/Ceph/upstream/Cephfs/full/attribution.txt
+++ b/knowledge/technical_manual/Ceph/upstream/Cephfs/full/attribution.txt
@@ -1,0 +1,3 @@
+Title of work: Handling a full Ceph file system
+Link to work: https://docs.ceph.com/en/squid/cephfs/full/
+Creators name: Amarnath

--- a/knowledge/technical_manual/Ceph/upstream/Cephfs/full/qna.yaml
+++ b/knowledge/technical_manual/Ceph/upstream/Cephfs/full/qna.yaml
@@ -1,0 +1,129 @@
+version: 3
+created_by: Amarnath
+domain: opensource_storage
+seed_examples:
+  - context: |
+      Overview of Handling a Full Ceph File System
+      --------------------------------------------
+
+      When a RADOS cluster reaches its ``mon_osd_full_ratio`` (default 95%) capacity, it is marked with the OSD full \
+      flag.
+      This flag pauses most normal RADOS client operations until the issue is resolved (e.g., by adding more capacity).
+      The Ceph file system has special handling mechanisms for this scenario, ensuring data safety and operational \
+      integrity.
+    questions_and_answers:
+      - question: |
+          What happens when a RADOS cluster reaches the ``mon_osd_full_ratio``?
+        answer: |
+          The cluster is marked with the OSD full flag, pausing most RADOS client operations until the issue is \
+          resolved.
+      - question: |
+          What is the default value for ``mon_osd_full_ratio``?
+        answer: |
+          The default value for ``mon_osd_full_ratio`` is 95%.
+      - question: |
+          How can the OSD full flag issue be resolved?
+        answer: |
+          The issue can be resolved by adding more capacity to the cluster.
+
+  - context: |
+      File System Behavior in Hammer and Later Releases
+      -------------------------------------------------
+
+      In Ceph Hammer and later releases, a full file system results in ENOSPC errors for:
+
+      - Data writes on the client.
+      - Metadata operations other than deletes and truncates.
+
+      Applications may not encounter the error until a ``fsync`` or ``fclose`` call.
+      ``fsync`` guarantees error reporting if data fails to persist, but ``fclose`` only reports errors if buffered \
+      data was flushed and failed to persist since the last write.
+    questions_and_answers:
+      - question: |
+          What error is returned for data writes on a full Ceph file system in Hammer and later releases?
+        answer: |
+          The ENOSPC error is returned for data writes.
+      - question: |
+          When is the ENOSPC error encountered by applications?
+        answer: |
+          It may be encountered during a ``fsync`` or ``fclose`` call.
+      - question: |
+          How does ``fsync`` differ from ``fclose`` in error reporting for full file systems?
+        answer: |
+          ``fsync`` guarantees error reporting if data fails to persist, while ``fclose`` only reports errors if \
+          buffered
+          data was flushed and failed to persist.
+
+  - context: |
+      Warnings and Recommendations for Full File Systems
+      --------------------------------------------------
+
+      Applications misbehaving on a full file system should ensure proper ``fsync()`` calls to verify data persistence.
+      Data writes in flight during the OSD full flag may be canceled. Clients update the ``osd_epoch_barrier`` to \
+      prevent \
+      interference with subsequent operations on affected files.
+    questions_and_answers:
+      - question: |
+          What should you check if an application misbehaves on a full file system?
+        answer: |
+          Ensure the application performs ``fsync()`` calls to verify data persistence before proceeding.
+      - question: |
+          What happens to data writes in flight during the OSD full flag?
+        answer: |
+          Data writes in flight may be canceled.
+      - question: |
+          What mechanism prevents interference with subsequent operations after canceled writes?
+        answer: |
+          Clients update the ``osd_epoch_barrier`` to ensure canceled operations do not interfere with subsequent \
+          access.
+
+  - context: |
+      Legacy Behavior in Pre-Hammer Releases
+      --------------------------------------
+
+      In pre-Hammer releases, MDS ignored the full status of the RADOS cluster. Data writes stalled until the \
+      cluster was no longer full, which led to two potential issues:
+
+      - Pending writes prevented clients from releasing files for deletion.
+      - Excessive metadata writes from creating empty files could completely exhaust OSD space, blocking further \
+      deletions.
+    questions_and_answers:
+      - question: |
+          How did MDS handle the full status of the RADOS cluster in pre-Hammer releases?
+        answer: |
+          MDS ignored the full status, causing data writes to stall until the cluster was no longer full.
+      - question: |
+          What problem occurred when clients had pending writes in pre-Hammer releases?
+        answer: |
+          Clients could not release files to the MDS for deletion, making it difficult to clear space.
+      - question: |
+          What was the risk of creating too many empty files in pre-Hammer releases?
+        answer: |
+          Metadata writes from creating empty files could exhaust OSD space, blocking further deletions.
+
+  - context: |
+      Summary of Full File System Handling
+      ------------------------------------
+
+      Ceph file systems handle full conditions by pausing most operations, returning ENOSPC errors for writes and \
+      metadata changes (except deletes and truncates), and leveraging ``fsync`` \
+      for reliable error detection. Legacy behaviors caused stalling and space exhaustion, but modern mechanisms \
+      ensure safe operations and client coordination.
+    questions_and_answers:
+      - question: |
+          Which operations return ENOSPC errors on a full file system in modern Ceph releases?
+        answer: |
+          Data writes and metadata changes (except deletes and truncates) return ENOSPC errors.
+      - question: |
+          What command ensures reliable error detection for writes on a full file system?
+        answer: |
+          The ``fsync`` command ensures reliable error detection for writes.
+      - question: |
+          What issues did legacy Ceph releases face with full file systems?
+        answer: |
+          Legacy releases faced stalling and space exhaustion due to ignored full status and excessive metadata writes.
+document_outline: Guide to Handling Full Ceph File Systems
+document:
+  repo: git@github.com:pavankumarag/ceph-instructlab-taxonomy-data.git
+  commit: b60d0d0
+  patterns: [upstream/doc/cephfs/full*.md]

--- a/knowledge/technical_manual/Ceph/upstream/Cephfs/mdcache/attribution.txt
+++ b/knowledge/technical_manual/Ceph/upstream/Cephfs/mdcache/attribution.txt
@@ -1,0 +1,3 @@
+Title of work: CephFS Distributed Metadata Cache
+Link to work: https://docs.ceph.com/en/squid/cephfs/mdcache/
+Creators name: Amarnath

--- a/knowledge/technical_manual/Ceph/upstream/Cephfs/mdcache/qna.yaml
+++ b/knowledge/technical_manual/Ceph/upstream/Cephfs/mdcache/qna.yaml
@@ -1,0 +1,117 @@
+version: 3
+created_by: Amarnath
+domain: opensource_storage
+seed_examples:
+  - context: |
+      Overview of CephFS Metadata Cache
+      ---------------------------------
+
+      In a Ceph file system, inode metadata and directory information are managed by the Ceph metadata server \
+      (MDS) and stored in a separate RADOS pool from file data. The MDS grants clients **capabilities** (caps) to \
+      cache or manipulate metadata. When another client requires access, the MDS revokes the caps, ensuring \
+      consistency and cache coherence across the cluster.
+    questions_and_answers:
+      - question: |
+          What role does the Ceph metadata server (MDS) play in managing inode metadata?
+        answer: |
+          The MDS manages inode metadata and directory information, storing it in a separate RADOS pool from file data.
+      - question: |
+          What are capabilities (caps) in CephFS?
+        answer: |
+          Caps grant clients the ability to cache and manipulate metadata or data associated with an inode.
+      - question: |
+          What happens when another client needs access to metadata held by a cap?
+        answer: |
+          The MDS revokes the cap and retrieves the updated metadata from the client if changes were made.
+
+  - context: |
+      Handling Capabilities in CephFS
+      -------------------------------
+
+      Clients with capabilities (caps) can cache metadata and make changes locally. \
+      If a capability conflicts with another client's operation or the MDS's actions, \
+      it is revoked. Clients must return revoked caps promptly, failing which they risk being blocklisted and \
+      unable to communicate with the cluster.
+    questions_and_answers:
+      - question: |
+          What can a client do with a capability in CephFS?
+        answer: |
+          A client can cache metadata and make changes locally when it holds the relevant capability.
+      - question: |
+          What happens if a client fails to return a revoked capability promptly?
+        answer: |
+          The client may be blocklisted and unable to communicate with the cluster.
+      - question: |
+          Why does the MDS revoke capabilities?
+        answer: |
+          To prevent conflicts between clients and ensure consistency when operations require metadata access.
+
+  - context: |
+      Client Metadata Requests in CephFS
+      ----------------------------------
+
+      Clients can query or request changes to inode metadata by either making requests to the MDS or serving \
+      information from their cache. Cached data can only be used if the client has the required caps. Requests to \
+      the MDS may also grant caps for subsequent operations.
+    questions_and_answers:
+      - question: |
+          How do clients query or change inode metadata in CephFS?
+        answer: |
+          Clients can either make requests to the MDS or use cached data if they have the necessary caps.
+      - question: |
+          What does the MDS provide when replying to client requests?
+        answer: |
+          The MDS may grant capabilities (caps) to the client for subsequent operations.
+      - question: |
+          When is it necessary for clients to request caps directly from the MDS?
+        answer: |
+          Clients must request caps directly to read or write file data.
+
+  - context: |
+      Distributed Locks in an MDS Cluster
+      -----------------------------------
+
+      In an MDS cluster, locks are used to manage inode operations. The authoritative MDS for an inode handles all \
+      change requests, while non-authoritative MDSs can obtain read locks to serve inode information. Locks ensure \
+      consistency by preventing conflicting operations during metadata updates.
+    questions_and_answers:
+      - question: |
+          What is the role of locks in an MDS cluster?
+        answer: |
+          Locks manage inode operations and prevent conflicting updates during metadata changes.
+      - question: |
+          What is the authoritative MDS in a CephFS cluster?
+        answer: |
+          It is the MDS responsible for managing all change requests for a specific inode.
+      - question: |
+          Can non-authoritative MDSs handle inode requests?
+        answer: |
+          Yes, they can obtain read locks to serve inode information but cannot make changes.
+
+  - context: |
+      Metadata Balancing and Pinning in CephFS
+      ----------------------------------------
+
+      Inode responsibilities are dynamically balanced among MDSs, with each MDS acting as the authoritative \
+      server for certain inodes. Subtrees can also be explicitly pinned to a single MDS to override dynamic balancing \
+      and ensure consistent handling for specific workloads.
+    questions_and_answers:
+      - question: |
+          How are inode responsibilities distributed in an MDS cluster?
+        answer: |
+          Inode responsibilities are dynamically balanced among MDSs, with each MDS becoming the authoritative server \
+          for certain inodes.
+      - question: |
+          What is subtree pinning in CephFS?
+        answer: |
+          Subtree pinning explicitly assigns a directory and its contents to a specific MDS, overriding dynamic \
+          balancing.
+      - question: |
+          Why might subtree pinning be useful in CephFS?
+        answer: |
+          It ensures consistent handling of specific workloads by assigning metadata management to a particular MDS.
+document_outline: Guide to CephFS Distributed Metadata Cache
+document:
+  repo: git@github.com:pavankumarag/ceph-instructlab-taxonomy-data.git
+  commit: b60d0d0
+  patterns: [upstream/doc/cephfs/mdcache*.md]

--- a/knowledge/technical_manual/Ceph/upstream/Cephfs/mds-config-ref/attribution.txt
+++ b/knowledge/technical_manual/Ceph/upstream/Cephfs/mds-config-ref/attribution.txt
@@ -1,0 +1,4 @@
+Title of work: MDS Config Reference
+Link to work: https://docs.ceph.com/en/squid/cephfs/mds-config-ref/
+License of the work: Apache 2.0
+Creators name: Amarnath

--- a/knowledge/technical_manual/Ceph/upstream/Cephfs/mds-config-ref/qna.yaml
+++ b/knowledge/technical_manual/Ceph/upstream/Cephfs/mds-config-ref/qna.yaml
@@ -1,0 +1,128 @@
+version: 3
+created_by: Amarnath
+domain: opensource_storage
+seed_examples:
+  - context: |
+      Cache and Directory Settings in MDS Configuration
+      -------------------------------------------------
+
+      Key configuration options for managing cache and directories in MDS:
+
+      - `mds_cache_mid`: Midpoint of the MDS cache size.
+      - `mds_dir_max_commit_size`: Maximum size for directory commits.
+      - `mds_dir_max_entries`: Maximum number of entries allowed in a directory.
+      - `mds_decay_halflife`: Halflife for cache decay.
+    questions_and_answers:
+      - question: |
+          What does the `mds_cache_mid` configuration option control?
+        answer: |
+          The `mds_cache_mid` option controls the midpoint of the MDS cache size.
+      - question: |
+          How can you set the maximum number of entries allowed in a directory?
+        answer: |
+          Use the `mds_dir_max_entries` configuration option to set the maximum number of entries allowed in a directory.
+      - question: |
+          What is the purpose of the `mds_decay_halflife` configuration?
+        answer: |
+          The `mds_decay_halflife` configuration controls the halflife for cache decay in MDS.
+
+  - context: |
+      Beacon and Client Configuration Options
+      ---------------------------------------
+
+      Configuration options related to MDS beaconing and client handling:
+
+      - `mds_beacon_interval`: Interval at which the MDS sends beacons to monitors.
+      - `mds_beacon_grace`: Grace period for missed MDS beacons before it is marked down.
+      - `mds_client_prealloc_inos`: Number of preallocated inodes for clients.
+      - `mds_reconnect_timeout`: Timeout for clients to reconnect during failover.
+    questions_and_answers:
+      - question: |
+          What does the `mds_beacon_interval` configuration control?
+        answer: |
+          The `mds_beacon_interval` configuration controls the interval at which MDS sends beacons to monitors.
+      - question: |
+          How can you configure the grace period for missed MDS beacons?
+        answer: |
+          Use the `mds_beacon_grace` configuration option to set the grace period for missed MDS beacons.
+      - question: |
+          What is the purpose of the `mds_client_prealloc_inos` setting?
+        answer: |
+          The `mds_client_prealloc_inos` setting specifies the number of preallocated inodes for clients.
+
+  - context: |
+      Load Balancing and Fragmentation in MDS
+      ---------------------------------------
+
+      Key options for managing MDS load balancing and fragmentation:
+
+      - `mds_bal_sample_interval`: Sampling interval for load balancing decisions.
+      - `mds_bal_split_size`: Minimum size of directories for splitting.
+      - `mds_bal_merge_size`: Maximum size of directories for merging.
+      - `mds_bal_fragment_fast_factor`: Factor controlling fast fragmentation for load balancing.
+    questions_and_answers:
+      - question: |
+          How is the sampling interval for load balancing controlled in MDS?
+        answer: |
+          The sampling interval for load balancing is controlled by the `mds_bal_sample_interval` configuration option.
+      - question: |
+          What does the `mds_bal_split_size` option define?
+        answer: |
+          The `mds_bal_split_size` option defines the minimum size of directories for splitting during load balancing.
+      - question: |
+          How can you configure the maximum size for directory merging in MDS?
+        answer: |
+          Use the `mds_bal_merge_size` configuration option to set the maximum size for directory merging.
+
+  - context: |
+      Debugging and Logging in MDS
+      ----------------------------
+
+      Options for enabling debugging and logging in MDS:
+
+      - `mds_log_skip_corrupt_events`: Skips over corrupt log events during playback.
+      - `mds_dump_cache_on_map`: Dumps the MDS cache when the MDS map changes.
+      - `mds_verify_scatter`: Verifies scatter distribution in MDS.
+      - `mds_debug_frag`: Enables debugging for fragment-related issues.
+    questions_and_answers:
+      - question: |
+          What does the `mds_log_skip_corrupt_events` configuration do?
+        answer: |
+          The `mds_log_skip_corrupt_events` configuration skips over corrupt log events during playback.
+      - question: |
+          How can you enable the dumping of the MDS cache when the MDS map changes?
+        answer: |
+          Use the `mds_dump_cache_on_map` configuration option to enable cache dumping on MDS map changes.
+      - question: |
+          What is the purpose of the `mds_verify_scatter` setting?
+        answer: |
+          The `mds_verify_scatter` setting verifies scatter distribution in MDS.
+
+  - context: |
+      Advanced and Testing Configurations
+      -----------------------------------
+
+      Configuration options for advanced and testing scenarios:
+
+      - `mds_kill_export_at`: Simulates MDS failure during export.
+      - `mds_inject_skip_replaying_inotable`: Skips replaying the inode table during recovery.
+      - `mds_min_caps_per_client`: Sets the minimum number of caps per client.
+      - `mds_symlink_recovery`: Controls recovery of broken symbolic links.
+    questions_and_answers:
+      - question: |
+          What does the `mds_kill_export_at` configuration simulate?
+        answer: |
+          The `mds_kill_export_at` configuration simulates MDS failure during an export operation.
+      - question: |
+          How can you set the minimum number of caps per client in MDS?
+        answer: |
+          Use the `mds_min_caps_per_client` configuration option to set the minimum number of caps per client.
+      - question: |
+          What is the purpose of the `mds_symlink_recovery` setting?
+        answer: |
+          The `mds_symlink_recovery` setting controls the recovery of broken symbolic links in MDS.
+document_outline: Guide to MDS Configuration Options
+document:
+  repo: git@github.com:pavankumarag/ceph-instructlab-taxonomy-data.git
+  commit: b60d0d0
+  patterns: [upstream/doc/cephfs/mds-config-ref*.md]

--- a/knowledge/technical_manual/Ceph/upstream/Cephfs/mds-journaling/attribution.txt
+++ b/knowledge/technical_manual/Ceph/upstream/Cephfs/mds-journaling/attribution.txt
@@ -1,0 +1,4 @@
+Title of work: MDS Journaling
+Link to work: https://docs.ceph.com/en/squid/cephfs/mds-journaling/
+License of the work: Apache 2.0
+Creators name: Amarnath

--- a/knowledge/technical_manual/Ceph/upstream/Cephfs/mds-journaling/qna.yaml
+++ b/knowledge/technical_manual/Ceph/upstream/Cephfs/mds-journaling/qna.yaml
@@ -1,0 +1,147 @@
+version: 3
+created_by: Amarnath
+domain: opensource_storage
+seed_examples:
+  - context: |
+      Overview of CephFS MDS Journaling
+      ---------------------------------
+
+      CephFS Metadata Servers (MDS) use journaling to ensure consistency and improve performance. Journals record
+      metadata events into the metadata pool before executing file system operations. Each active MDS maintains its
+      own journal in the metadata pool, which is striped over multiple objects. Old entries are trimmed periodically.
+
+      Journaling provides:
+      - **Consistency**: Ensures file system state consistency during MDS failover by replaying journal events.
+      - **Performance**: Sequential journal updates improve speed, and large journals warm cache for standby MDS.
+
+      Journals are essential for metadata updates, client sessions, and directory operations.
+    questions_and_answers:
+      - question: |
+          What is the purpose of journaling in CephFS MDS?
+        answer: |
+          Journaling ensures file system consistency during MDS failover and improves performance by enabling
+          sequential updates and caching.
+      - question: |
+          How does CephFS MDS manage its journals?
+        answer: |
+          Each active MDS maintains its own journal in the metadata pool, striped over multiple objects and trimmed
+          periodically.
+      - question: |
+          What types of information are recorded in CephFS journals?
+        answer: |
+          Journals record metadata updates, client sessions, directory operations, and more.
+
+  - context: |
+      Journal Event Types in CephFS
+      -----------------------------
+
+      CephFS journals various types of events, including:
+      - `EVENT_COMMITTED`: Marks a request as committed.
+      - `EVENT_FRAGMENT`: Tracks directory fragmentation stages.
+      - `EVENT_OPEN`: Tracks inodes with open file handles.
+      - `EVENT_RESETJOURNAL`: Marks a journal as reset post-truncation.
+      - `EVENT_SESSION`: Tracks open client sessions.
+      - `EVENT_UPDATE`: Logs file operations on an inode.
+      - `EVENT_SEGMENT`: Logs a new journal segment boundary.
+
+      These events help MDS maintain state consistency and manage client sessions. Tools like `cephfs-journal-tool`
+      can be used to view and manage these events.
+    questions_and_answers:
+      - question: |
+          What is the purpose of `EVENT_FRAGMENT` in CephFS journals?
+        answer: |
+          `EVENT_FRAGMENT` tracks various stages of directory fragmentation, such as split and merge.
+      - question: |
+          How can you view journal events in CephFS?
+        answer: |
+          Use the `cephfs-journal-tool --rank=<fs>:<rank> event get list` command to view journal events.
+      - question: |
+          What does the `EVENT_UPDATE` event type log in CephFS journals?
+        answer: |
+          `EVENT_UPDATE` logs file operations performed on an inode.
+
+  - context: |
+      CephFS Journal Segments
+      -----------------------
+
+      CephFS MDS journals are divided into logical segments (LogSegments) that group metadata updates for trimming
+      and replay purposes. Segments allow MDS to batch updates for performance and replay consistency. Expired segments
+      are eligible for deletion once their updates are flushed to RADOS objects.
+
+      Types of segment boundaries:
+      - **ESegment**: Lightweight segment boundary.
+      - **ESubtreeMap**: Marks the beginning of a major segment and includes subtree map details.
+      - **EResetJournal**: Marks the journal as reset.
+      - **ELid**: Indicates a new journal sequence number or initial state.
+
+      Major segments ensure consistent replay by including a subtree map.
+    questions_and_answers:
+      - question: |
+          What are journal segments in CephFS?
+        answer: |
+          Journal segments (LogSegments) group metadata updates for replay and trimming purposes.
+      - question: |
+          What is the purpose of `ESubtreeMap` in CephFS journals?
+        answer: |
+          `ESubtreeMap` marks the beginning of a major segment and ensures consistent replay by including a subtree map.
+      - question: |
+          When is a journal segment considered expired in CephFS?
+        answer: |
+          A journal segment is expired when all its updates are flushed to RADOS objects and it is no longer needed.
+
+  - context: |
+      Managing Journal Configuration in CephFS
+      ----------------------------------------
+
+      Several configurations control the behavior of MDS journaling:
+      - `mds_log_events_per_segment`: Target size of a log segment in terms of the number of events.
+      - `mds_log_major_segment_event_ratio`: Determines frequency of major segments by setting a ratio of non-\
+      `ESubtreeMap`
+        events per major segment.
+      - `mds_log_max_segments`: Maximum number of journal segments allowed.
+
+      These settings optimize journal size and trimming frequency for performance and reliability.
+    questions_and_answers:
+      - question: |
+          What does the `mds_log_events_per_segment` configuration control?
+        answer: |
+          It controls the target size of a log segment in terms of the number of events.
+      - question: |
+          How does `mds_log_major_segment_event_ratio` impact journaling?
+        answer: |
+          It determines the frequency of major segments by setting a ratio of non-`ESubtreeMap` events per major \
+          segment.
+      - question: |
+          What happens if the number of journal segments exceeds `mds_log_max_segments`?
+        answer: |
+          The MDS trims expired segments to reduce the number of journal segments to below the maximum limit.
+
+  - context: |
+      Tools for Managing CephFS Journals
+      ----------------------------------
+
+      The `cephfs-journal-tool` utility allows administrators to examine, repair, and manage CephFS journals.
+      Common commands include:
+      - `event get list`: Lists all journal events.
+      - `event splice`: Erases or repairs specific journal events.
+      - `event apply`: Reapplies metadata updates from journal events.
+
+      These tools are essential for troubleshooting and ensuring metadata consistency in CephFS.
+    questions_and_answers:
+      - question: |
+          What is the purpose of `cephfs-journal-tool`?
+        answer: |
+          `cephfs-journal-tool` is used to examine, repair, and manage CephFS journals for metadata consistency.
+      - question: |
+          How can you list all journal events using `cephfs-journal-tool`?
+        answer: |
+          Use the command `cephfs-journal-tool --rank=<fs>:<rank> event get list`.
+      - question: |
+          What does the `event apply` command do in `cephfs-journal-tool`?
+        answer: |
+          The `event apply` command reapplies metadata updates from journal events to the file system.
+document_outline: Guide to managing and understanding MDS Journaling in CephFS
+document:
+  repo: git@github.com:pavankumarag/ceph-instructlab-taxonomy-data.git
+  commit: b60d0d0
+  patterns: [upstream/doc/cephfs/mds-journaling.*.md]

--- a/knowledge/technical_manual/Ceph/upstream/Cephfs/mds-states/attribution.txt
+++ b/knowledge/technical_manual/Ceph/upstream/Cephfs/mds-states/attribution.txt
@@ -1,0 +1,4 @@
+Title of work: MDS States
+Link to work: https://docs.ceph.com/en/squid/cephfs/mds-states/
+License of the work: Apache 2.0
+Creators name: Amarnath

--- a/knowledge/technical_manual/Ceph/upstream/Cephfs/mds-states/qna.yaml
+++ b/knowledge/technical_manual/Ceph/upstream/Cephfs/mds-states/qna.yaml
@@ -1,0 +1,130 @@
+version: 3
+created_by: Amarnath
+domain: opensource_storage
+seed_examples:
+  - context: |
+      Common MDS States in CephFS
+      ---------------------------
+
+      Metadata Servers (MDS) in CephFS operate in various states. Key common states include:
+
+      - **up:active**: Indicates the MDS is operational and managing metadata for its rank.
+      - **up:standby**: The MDS is ready to take over for a failed active MDS.
+      - **up:standby_replay**: The MDS is following the live journal of an active MDS for quicker failover, but it \
+      cannot
+        take over for other ranks.
+    questions_and_answers:
+      - question: |
+          What does the MDS state `up:active` signify in CephFS?
+        answer: |
+          It signifies that the MDS is operational and managing metadata for its assigned rank.
+      - question: |
+          What is the purpose of the `up:standby` state for an MDS?
+        answer: |
+          The `up:standby` state indicates the MDS is ready to take over if an active MDS fails.
+      - question: |
+          Why might an MDS be in the `up:standby_replay` state?
+        answer: |
+          An MDS in the `up:standby_replay` state is following the live journal of an active MDS for quicker failover,
+          but it cannot take over for other ranks.
+
+  - context: |
+      Transitory MDS States
+      ---------------------
+
+      MDS states during transitions include:
+
+      - **up:creating**: The MDS is creating a new rank by constructing required metadata.
+      - **up:replay**: The MDS is recovering its journal after a failure to ensure a consistent state.
+      - **up:reconnect**: The MDS solicits reconnections from clients to restore sessions.
+    questions_and_answers:
+      - question: |
+          What happens during the `up:creating` state of an MDS?
+        answer: |
+          The MDS is creating a new rank by constructing necessary metadata like journals.
+      - question: |
+          What does the `up:replay` state indicate for an MDS?
+        answer: |
+          The `up:replay` state indicates the MDS is recovering its journal to ensure a consistent file system state.
+      - question: |
+          Why does an MDS enter the `up:reconnect` state?
+        answer: |
+          An MDS enters the `up:reconnect` state to solicit reconnections from clients to restore their sessions.
+
+  - context: |
+      Failed MDS States
+      -----------------
+
+      When issues occur, MDS ranks may be marked with failed states:
+
+      - **down:failed**: Indicates no MDS is available to manage the rank. This state occurs if there are no suitable
+        standby MDS daemons.
+      - **down:damaged**: Indicates metadata damage that requires operator intervention for recovery.
+      - **down:stopped**: Indicates the rank has been manually stopped by reducing the `max_mds` parameter.
+    questions_and_answers:
+      - question: |
+          What does the `down:failed` state indicate in CephFS?
+        answer: |
+          The `down:failed` state indicates no MDS is available to manage the rank, possibly due to a lack of suitable
+          standby MDS daemons.
+      - question: |
+          What action is required if a rank is in the `down:damaged` state?
+        answer: |
+          Operator intervention is required to recover the metadata damage for the rank in the `down:damaged` state.
+      - question: |
+          Why might a rank be marked as `down:stopped` in CephFS?
+        answer: |
+          A rank is marked as `down:stopped` when it is manually stopped by reducing the `max_mds` parameter.
+
+  - context: |
+      Transitioning to Active States
+      ------------------------------
+
+      The MDS undergoes several transitional states before becoming active:
+
+      - **up:resolve**: The MDS resolves inter-MDS operations when multiple ranks exist.
+      - **up:rejoin**: The MDS re-establishes inter-MDS locks and joins the cluster cache.
+      - **up:clientreplay**: The MDS replays client requests that were not journaled before becoming active.
+    questions_and_answers:
+      - question: |
+          What does the `up:resolve` state indicate in CephFS?
+        answer: |
+          The `up:resolve` state indicates the MDS is resolving inter-MDS operations in a multi-rank file system.
+      - question: |
+          What happens during the `up:rejoin` state of an MDS?
+        answer: |
+          During the `up:rejoin` state, the MDS re-establishes inter-MDS locks and joins the cluster cache.
+      - question: |
+          Why does an MDS enter the `up:clientreplay` state?
+        answer: |
+          An MDS enters the `up:clientreplay` state to replay client requests that were not journaled before becoming \
+          active.
+
+  - context: |
+      MDS State Transitions in CephFS
+      -------------------------------
+
+      CephFS MDS state transitions follow a defined flow:
+
+      - MDS starts in the **up:boot** state and is assigned a role (e.g., standby or active).
+      - When an active MDS fails, a standby MDS transitions through states like **up:replay** and **up:resolve** to \
+      recover.
+      - If recovery is successful, the MDS becomes **up:active**; otherwise, the rank may be marked **down:failed**.
+    questions_and_answers:
+      - question: |
+          What is the starting state of an MDS during initialization?
+        answer: |
+          The starting state of an MDS during initialization is `up:boot`.
+      - question: |
+          What sequence of states does a standby MDS follow to take over an active rank?
+        answer: |
+          A standby MDS transitions through states like `up:replay` and `up:resolve` to take over an active rank.
+      - question: |
+          What happens if an MDS fails to recover a rank?
+        answer: |
+          If an MDS fails to recover a rank, the rank may be marked as `down:failed`.
+document_outline: Guide to MDS States and Transitions in CephFS
+document:
+  repo: git@github.com:pavankumarag/ceph-instructlab-taxonomy-data.git
+  commit: b60d0d0
+  patterns: [upstream/doc/cephfs/mds-states*.md]

--- a/knowledge/technical_manual/Ceph/upstream/Cephfs/mount-using-kernel-driver/attribution.txt
+++ b/knowledge/technical_manual/Ceph/upstream/Cephfs/mount-using-kernel-driver/attribution.txt
@@ -1,0 +1,4 @@
+Title of work: Mount CephFS using Kernel Driver
+Link to work: https://docs.ceph.com/en/squid/cephfs/mount-using-kernel-driver/
+License of the work: Apache 2.0
+Creators name: Amarnath

--- a/knowledge/technical_manual/Ceph/upstream/Cephfs/mount-using-kernel-driver/qna.yaml
+++ b/knowledge/technical_manual/Ceph/upstream/Cephfs/mount-using-kernel-driver/qna.yaml
@@ -1,0 +1,136 @@
+version: 3
+created_by: Amarnath
+domain: opensource_storage
+seed_examples:
+  - context: |
+      Overview of CephFS Kernel Driver
+      --------------------------------
+
+      The CephFS kernel driver is part of the Linux kernel, allowing CephFS to be mounted as a regular file
+      system with native kernel performance. It supports backward compatibility with the old mount syntax
+      but recommends the new device string syntax for better functionality. The kernel driver requires
+      monitor addresses and user credentials to mount CephFS securely.
+    questions_and_answers:
+      - question: |
+          What is the CephFS kernel driver?
+        answer: |
+          The CephFS kernel driver is part of the Linux kernel, allowing CephFS to be mounted as a regular
+          file system with native kernel performance.
+      - question: |
+          Why is the new device string syntax recommended for mounting CephFS?
+        answer: |
+          The new syntax improves functionality and compatibility with modern systems, although the old
+          syntax is still supported for backward compatibility.
+      - question: |
+          What details are required to mount CephFS using the kernel driver?
+        answer: |
+          Monitor addresses and user credentials are required to mount CephFS securely.
+
+  - context: |
+      Prerequisites for Mounting CephFS
+      ---------------------------------
+
+      Before mounting CephFS using the kernel driver, ensure the following:
+      - The `mount.ceph` helper is installed to simplify mounting.
+      - Use a kernel version that supports CephFS features; a 4.x kernel or later is recommended for Ceph
+        10.x (Jewel) and above.
+      - For distributions with CephFS support, verify backported fixes with your vendor.
+    questions_and_answers:
+      - question: |
+          What is the role of the `mount.ceph` helper in mounting CephFS?
+        answer: |
+          The `mount.ceph` helper simplifies the mounting process by automatically providing monitor
+          addresses and user credentials.
+      - question: |
+          Which kernel version is recommended for Ceph 10.x (Jewel) and later?
+        answer: |
+          A 4.x kernel or later is recommended for Ceph 10.x (Jewel) and above.
+      - question: |
+          Why should you check with your vendor for CephFS support in distributions?
+        answer: |
+          Vendors are responsible for backporting CephFS fixes to their stable kernels.
+
+  - context: |
+      Mounting CephFS Using Kernel Driver
+      -----------------------------------
+
+      Use the `mount` command with the `-t ceph` option to mount CephFS. The command requires:
+      - A device string specifying the CephX user, cluster FSID, and file system name.
+      - Options for monitor addresses (`mon_addr`) and secret keys (`secret` or `secretfile`).
+      Example:
+      ```
+      mount -t ceph cephuser@<fsid>.cephfs=/ /mnt/mycephfs -o mon_addr=192.168.0.1:6789,secretfile=/path/to/secret
+      ```
+    questions_and_answers:
+      - question: |
+          How do you specify the CephX user and file system name when mounting CephFS?
+        answer: |
+          Include the CephX user and file system name in the device string, e.g., `cephuser@<fsid>.cephfs=/`.
+      - question: |
+          What option can you use to pass a secret key without exposing it in the shell command history?
+        answer: |
+          Use the `secretfile` option to specify the path to a file containing the secret key.
+      - question: |
+          How can you mount a subtree of the CephFS root?
+        answer: |
+          Append the desired path to the device string, e.g., `cephuser@<fsid>.cephfs=/subvolume/dir`.
+
+  - context: |
+      Backward Compatibility and Mount Helper
+      ---------------------------------------
+
+      The old CephFS mount syntax is still supported for backward compatibility. For example:
+      ```
+      mount -t ceph :/ /mnt/mycephfs -o name=admin
+      ```
+      The `mount.ceph` helper can automatically retrieve monitor addresses and user credentials, simplifying
+      the process. For non-default file systems, use the `fs=` option:
+      ```
+      mount -t ceph :/ /mnt/mycephfs -o name=admin,fs=cephfs2
+      ```
+    questions_and_answers:
+      - question: |
+          What is the purpose of the `mount.ceph` helper?
+        answer: |
+          The `mount.ceph` helper simplifies mounting by automatically retrieving monitor addresses and
+          user credentials.
+      - question: |
+          How do you mount a non-default file system using the old syntax?
+        answer: |
+          Use the `fs=` option, e.g., `mount -t ceph :/ /mnt/mycephfs -o name=admin,fs=cephfs2`.
+      - question: |
+          Is the old CephFS mount syntax still supported?
+        answer: |
+          Yes, the old syntax is supported for backward compatibility.
+
+  - context: |
+      Persistent Mounts and Unmounting
+      --------------------------------
+
+      To mount CephFS persistently, add an entry to `/etc/fstab`:
+      ```
+      cephuser@.cephfs=/ /mnt/ceph ceph mon_addr=192.168.0.1:6789,secretfile=/path/to/secretfile,noatime,_netdev 0 0
+      ```
+      To unmount CephFS, use the `umount` command:
+      ```
+      umount /mnt/cephfs
+      ```
+      Ensure that no processes are using the file system before unmounting.
+    questions_and_answers:
+      - question: |
+          How do you persistently mount CephFS using `/etc/fstab`?
+        answer: |
+          Add an entry specifying the CephX user, file system, and options like `mon_addr` and `secretfile`.
+      - question: |
+          How do you unmount CephFS?
+        answer: |
+          Use the `umount` command, e.g., `umount /mnt/cephfs`.
+      - question: |
+          What should you ensure before unmounting CephFS?
+        answer: |
+          Ensure that no processes are using the file system directories before unmounting.
+document_outline: Guide to Mounting CephFS Using Kernel Driver
+document:
+  repo: git@github.com:pavankumarag/ceph-instructlab-taxonomy-data.git
+  commit: b60d0d0
+  patterns: [upstream/doc/cephfs/mount-using-kernel-driver*.md]

--- a/knowledge/technical_manual/Ceph/upstream/Cephfs/multimds/attribution.txt
+++ b/knowledge/technical_manual/Ceph/upstream/Cephfs/multimds/attribution.txt
@@ -1,0 +1,4 @@
+Title of work: Configuring multiple active MDS daemons
+Link to work: https://docs.ceph.com/en/squid/cephfs/multimds/
+License of the work: Apache 2.0
+Creators name: Amarnath

--- a/knowledge/technical_manual/Ceph/upstream/Cephfs/multimds/qna.yaml
+++ b/knowledge/technical_manual/Ceph/upstream/Cephfs/multimds/qna.yaml
@@ -1,0 +1,148 @@
+version: 3
+created_by: Amarnath
+domain: opensource_storage
+seed_examples:
+  - context: |
+      Overview of Multiple Active MDS Daemons in CephFS
+      -------------------------------------------------
+
+      By default, CephFS is configured with a single active MDS daemon. For large-scale systems needing higher metadata
+      performance, multiple active MDS daemons can be configured. This setup allows sharing of the metadata workload
+      across MDS daemons, enhancing performance for workloads with many clients or parallel operations.
+
+      To enable this, set the `max_mds` parameter to the desired number of active MDS daemons. Standby daemons are
+      recommended for high availability to ensure failover in case of MDS failures.
+    questions_and_answers:
+      - question: |
+          Why would you configure multiple active MDS daemons in CephFS?
+        answer: |
+          To enhance metadata performance for workloads with many clients or parallel operations by sharing the
+          workload across multiple MDS daemons.
+      - question: |
+          What parameter controls the number of active MDS daemons in CephFS?
+        answer: |
+          The `max_mds` parameter controls the number of active MDS daemons.
+      - question: |
+          Why are standby MDS daemons recommended in a multi-MDS configuration?
+        answer: |
+          Standby MDS daemons ensure high availability by taking over in case of failures of active MDS daemons.
+
+  - context: |
+      Manual Directory Pinning in CephFS
+      ----------------------------------
+
+      In multi-MDS configurations, directory trees can be explicitly pinned to specific MDS ranks using the \
+      `ceph.dir.pin`
+      extended attribute. This allows administrators to control the distribution of metadata for performance \
+      optimization.
+
+      Example:
+      ```
+      setfattr -n ceph.dir.pin -v <rank> <directory>
+      ```
+
+      A value of `-1` indicates no pinning. Pins can be inherited by child directories or overridden by setting a \
+      new pin
+      on a child directory.
+    questions_and_answers:
+      - question: |
+          What is the purpose of manual directory pinning in CephFS?
+        answer: |
+          Manual directory pinning allows administrators to control the distribution of metadata by assigning specific
+          directories to particular MDS ranks.
+      - question: |
+          How do you set a directory pin in CephFS?
+        answer: |
+          Use the `setfattr` command with the `ceph.dir.pin` extended attribute, e.g., \
+          `setfattr -n ceph.dir.pin -v <rank> <directory>`.
+      - question: |
+          What happens if a parent directory is pinned but a child directory is not explicitly pinned?
+        answer: |
+          The child directory inherits the pin from its closest parent with a set pin.
+
+  - context: |
+      Ephemeral Pinning Policies in CephFS
+      ------------------------------------
+
+      Ephemeral pinning automatically assigns directories to MDS ranks based on their inode numbers and \
+      consistent hashing.
+      Policies:
+      - **Distributed Ephemeral Pins**: Fragments and distributes subtrees across ranks.
+      - **Random Ephemeral Pins**: Pins a percentage of directories under a path.
+
+      Use `ceph.dir.pin.distributed` or `ceph.dir.pin.random` attributes to enable these policies.
+    questions_and_answers:
+      - question: |
+          What is the purpose of ephemeral pinning in CephFS?
+        answer: |
+          Ephemeral pinning automatically distributes directories across MDS ranks based on inode numbers and \
+          consistent hashing.
+      - question: |
+          How do distributed ephemeral pins work?
+        answer: |
+          Distributed ephemeral pins fragment and distribute subtrees across MDS ranks, spreading metadata load.
+      - question: |
+          What attribute enables random ephemeral pinning in CephFS?
+        answer: |
+          The `ceph.dir.pin.random` attribute enables random ephemeral pinning.
+
+  - context: |
+      Dynamic Subtree Partitioning in CephFS
+      --------------------------------------
+
+      CephFS uses a dynamic balancer to optimize metadata distribution by splitting or merging subtrees and placing
+      them on underutilized MDS ranks. This feature is controlled by the `balance_automate` option.
+
+      Example:
+      ```
+      ceph fs set <fs_name> balance_automate true
+      ```
+
+      Use `bal_rank_mask` to limit the balancer to specific ranks for mixed static and dynamic partitioning setups.
+    questions_and_answers:
+      - question: |
+          What is the purpose of dynamic subtree partitioning in CephFS?
+        answer: |
+          Dynamic subtree partitioning improves file system throughput by splitting or merging subtrees and placing
+          them on underutilized MDS ranks.
+      - question: |
+          How do you enable the dynamic balancer in CephFS?
+        answer: |
+          Use the command `ceph fs set <fs_name> balance_automate true` to enable the dynamic balancer.
+      - question: |
+          What does the `bal_rank_mask` option do in CephFS?
+        answer: |
+          The `bal_rank_mask` option limits the dynamic balancer to specific active MDS ranks.
+
+  - context: |
+      Reducing the Number of Active MDS Daemons in CephFS
+      ---------------------------------------------------
+
+      To reduce the number of active MDS daemons, lower the `max_mds` parameter. The cluster will incrementally stop
+      extra ranks by transferring metadata to the remaining active daemons.
+
+      Example:
+      ```
+      ceph fs set <fs_name> max_mds <new_value>
+      ```
+
+      The stopping process may take seconds to minutes as metadata is handed off. If issues arise, \
+      investigate potential bugs.
+    questions_and_answers:
+      - question: |
+          How do you reduce the number of active MDS daemons in CephFS?
+        answer: |
+          Lower the `max_mds` parameter using the command `ceph fs set <fs_name> max_mds <new_value>`.
+      - question: |
+          What happens to metadata when reducing the number of active MDS daemons?
+        answer: |
+          Metadata from stopped ranks is incrementally transferred to the remaining active daemons.
+      - question: |
+          Why might an MDS daemon appear stuck in the stopping state?
+        answer: |
+          This could indicate a bug and should be investigated.
+document_outline: Guide to configuring multiple active MDS daemons and metadata partitioning in CephFS
+document:
+  repo: git@github.com:pavankumarag/ceph-instructlab-taxonomy-data.git
+  commit: b60d0d0
+  patterns: [upstream/doc/cephfs/multimds*.md]

--- a/knowledge/technical_manual/Ceph/upstream/Cephfs/nfs/attribution.txt
+++ b/knowledge/technical_manual/Ceph/upstream/Cephfs/nfs/attribution.txt
@@ -1,0 +1,4 @@
+Title of work: NFS
+Link to work: https://docs.ceph.com/en/squid/cephfs/nfs/
+License of the work: Apache 2.0
+Creators name: Amarnath

--- a/knowledge/technical_manual/Ceph/upstream/Cephfs/nfs/qna.yaml
+++ b/knowledge/technical_manual/Ceph/upstream/Cephfs/nfs/qna.yaml
@@ -1,0 +1,142 @@
+version: 3
+created_by: Amarnath
+domain: opensource_storage
+seed_examples:
+  - context: |
+      Overview of NFS-Ganesha and CephFS Integration
+      ---------------------------------------------
+
+      NFS-Ganesha is a protocol server that allows CephFS namespaces to be exported over NFS. Key points include:
+
+      - NFS-Ganesha supports the integration of CephFS using the FSAL_CEPH plugin.
+      - The preferred way to manage NFS-Ganesha clusters and CephFS exports is using `ceph nfs` commands with \
+      cephadm or rook.
+      - Recommended NFS-Ganesha version is 3.5+ with Ceph Pacific (16.2.x) or later.
+    questions_and_answers:
+      - question: |
+          What is NFS-Ganesha used for in relation to CephFS?
+        answer: |
+          NFS-Ganesha allows CephFS namespaces to be exported over NFS using the FSAL_CEPH plugin.
+      - question: |
+          What is the recommended version of NFS-Ganesha for use with Ceph Pacific?
+        answer: |
+          The recommended version is NFS-Ganesha 3.5 or later with Ceph Pacific (16.2.x) or later.
+      - question: |
+          Which plugin in NFS-Ganesha is used to integrate with CephFS?
+        answer: |
+          The FSAL_CEPH plugin is used to integrate NFS-Ganesha with CephFS.
+
+  - context: |
+      Configuring NFS-Ganesha for CephFS
+      ----------------------------------
+
+      To set up NFS-Ganesha for CephFS:
+
+      - Use the `ganesha.conf` configuration file with FSAL_CEPH.
+      - Minimize Ganesha caching to optimize performance with libcephfs clients.
+      - Store client recovery data in RADOS OMAP key-value interface.
+      - Mandate NFSv4.1+ protocol for access.
+      - Ensure CephFS metadata and data pools are correctly set using:
+        ```
+        ceph osd pool application set <cephfs_metadata_pool> cephfs <cephfs_data_pool> cephfs
+        ```
+    questions_and_answers:
+      - question: |
+          Which configuration file is used to set up NFS-Ganesha for CephFS?
+        answer: |
+          The `ganesha.conf` configuration file is used to set up NFS-Ganesha for CephFS.
+      - question: |
+          Why is it recommended to minimize Ganesha caching when using FSAL_CEPH?
+        answer: |
+          Minimizing Ganesha caching is recommended because libcephfs clients also cache aggressively.
+      - question: |
+          How can you set the CephFS metadata and data pools for NFS-Ganesha?
+        answer: |
+          Use the command: `ceph osd pool application set <cephfs_metadata_pool> cephfs <cephfs_data_pool> cephfs`.
+
+  - context: |
+      Requirements for NFS-Ganesha with CephFS
+      ----------------------------------------
+
+      Setting up NFS-Ganesha for CephFS requires:
+
+      - A Ceph file system configured in the cluster.
+      - NFS-Ganesha-related packages such as `libcephfs2`, `nfs-ganesha`, and `nfs-ganesha-ceph` installed on the \
+      NFS server host.
+      - The NFS-Ganesha server host must be connected to the Ceph public network.
+    questions_and_answers:
+      - question: |
+          What packages are required to set up NFS-Ganesha for CephFS?
+        answer: |
+          The required packages are `libcephfs2`, `nfs-ganesha`, and `nfs-ganesha-ceph`.
+      - question: |
+          What network should the NFS-Ganesha server host be connected to?
+        answer: |
+          The NFS-Ganesha server host must be connected to the Ceph public network.
+      - question: |
+          What is the primary requirement for setting up NFS-Ganesha for CephFS?
+        answer: |
+          A Ceph file system must be configured in the cluster.
+
+  - context: |
+      Using NFSv4 Clients with NFS-Ganesha
+      ------------------------------------
+
+      NFS-Ganesha exports are best accessed using NFSv4.1+ protocols to leverage session benefits. Mount commands:
+
+      ```
+      mount -t nfs -o nfsvers=4.1,proto=tcp <ganesha-host-name>:<ganesha-pseudo-path> <mount-point>
+      ```
+
+      - Replace `<ganesha-host-name>` with the NFS-Ganesha server's hostname.
+      - Replace `<ganesha-pseudo-path>` with the export path.
+      - Replace `<mount-point>` with the local mount directory path.
+    questions_and_answers:
+      - question: |
+          Which NFS protocol version is recommended for mounting NFS-Ganesha exports?
+        answer: |
+          The NFSv4.1+ protocol is recommended for mounting NFS-Ganesha exports.
+      - question: |
+          What does `<ganesha-host-name>` represent in the mount command?
+        answer: |
+          `<ganesha-host-name>` represents the hostname of the NFS-Ganesha server.
+      - question: |
+          Why is NFSv4.1+ preferred for mounting NFS-Ganesha exports?
+        answer: |
+          NFSv4.1+ is preferred for its session benefits.
+
+  - context: |
+      Configuring libcephfs Clients for NFS-Ganesha
+      --------------------------------------------
+
+      Configure `ceph.conf` for libcephfs clients:
+
+      - Use the `[client]` section with the `mon_host` option to connect to Ceph monitors.
+      - Generate minimal configuration using:
+        ```
+        ceph config generate-minimal-conf
+        ```
+      Example configuration:
+      ```
+      [client]
+          mon host = [v2:192.168.1.7:3300,v1:192.168.1.7:6789], [v2:192.168.1.8:3300,v1:192.168.1.8:6789], \
+      [v2:192.168.1.9:3300,v1:192.168.1.9:6789]
+      ```
+    questions_and_answers:
+      - question: |
+          How do you specify monitor hosts for libcephfs clients in `ceph.conf`?
+        answer: |
+          Use the `[client]` section with the `mon_host` option to specify monitor hosts.
+      - question: |
+          Which command generates a minimal configuration file for libcephfs clients?
+        answer: |
+          The command `ceph config generate-minimal-conf` generates a minimal configuration file for libcephfs clients.
+      - question: |
+          What is the purpose of the `[client]` section in `ceph.conf` for libcephfs clients?
+        answer: |
+          The `[client]` section is used to configure options like `mon_host` to connect to Ceph monitors.
+document_outline: Guide to Configuring NFS-Ganesha with CephFS
+document:
+  repo: git@github.com:pavankumarag/ceph-instructlab-taxonomy-data.git
+  commit: b60d0d0
+  patterns: [upstream/doc/cephfs/nfs*.md]

--- a/knowledge/technical_manual/Ceph/upstream/Cephfs/recover-fs-after-mon-store-loss/attribution.txt
+++ b/knowledge/technical_manual/Ceph/upstream/Cephfs/recover-fs-after-mon-store-loss/attribution.txt
@@ -1,0 +1,4 @@
+Title of work: Recovering the file system after catastrophic Monitor store loss
+Link to work: https://docs.ceph.com/en/squid/cephfs/recover-fs-after-mon-store-loss/
+License of the work: Apache 2.0
+Creators name: Amarnath

--- a/knowledge/technical_manual/Ceph/upstream/Cephfs/recover-fs-after-mon-store-loss/qna.yaml
+++ b/knowledge/technical_manual/Ceph/upstream/Cephfs/recover-fs-after-mon-store-loss/qna.yaml
@@ -1,0 +1,134 @@
+version: 3
+created_by: Amarnath
+domain: opensource_storage
+seed_examples:
+  - context: |
+      Recovering a File System After Monitor Store Loss
+      -------------------------------------------------
+
+      If all monitor stores in a Ceph cluster are lost, they can be rebuilt using OSDs. However, the rebuilt monitor
+      stores don't include file system maps (FSMap). For a single active MDS file system, recovery involves recreating
+      the FSMap with basic defaults and allowing MDS daemons to recover from existing journal/metadata stored in pools.
+
+      To recreate the file system with the recovered pools, use:
+      ```
+      ceph fs new <fs_name> <metadata_pool> <data_pool> --force --recover
+      ```
+
+    questions_and_answers:
+      - question: |
+          What happens to FSMap during monitor store loss recovery?
+        answer: |
+          The FSMap is not restored during monitor store recovery and must be recreated separately.
+      - question: |
+          How can you recreate a file system after rebuilding monitor stores?
+        answer: |
+          Use the command `ceph fs new <fs_name> <metadata_pool> <data_pool> --force --recover` \
+          to recreate the file system.
+      - question: |
+          What does the `--recover` flag do during FSMap recreation?
+        answer: |
+          It ensures rank 0 uses existing in-RADOS metadata and prevents standby MDS daemons \
+          from activating the file system.
+  - context: |
+      Allowing Standby MDS Daemons to Join the File System
+      ----------------------------------------------------
+
+      After recreating the FSMap, standby MDS daemons can be allowed to join the file system by setting it to joinable:
+      ```
+      ceph fs set <fs_name> joinable true
+      ```
+
+      This step allows MDS daemons to activate and manage the file system metadata.
+
+    questions_and_answers:
+      - question: |
+          How can standby MDS daemons be allowed to join a recovered file system?
+        answer: |
+          Use the command `ceph fs set <fs_name> joinable true` to allow standby MDS daemons to join the file system.
+      - question: |
+          What does the `joinable` setting do for the file system?
+        answer: |
+          It enables standby MDS daemons to activate and manage the file system metadata.
+      - question: |
+          Why is it necessary to set the file system to joinable after FSMap recreation?
+        answer: |
+          To allow standby MDS daemons to join and activate the file system.
+  - context: |
+      Verifying File System Recovery
+      ------------------------------
+
+      Once the FSMap is recreated and standby MDS daemons are allowed to join, check the file system's state to ensure \
+      it is no longer degraded and has an active MDS:
+      ```
+      ceph fs status
+      ```
+
+      This command provides information about the file system, including its MDS status.
+
+    questions_and_answers:
+      - question: |
+          How can you verify the state of a recovered file system?
+        answer: |
+          Use the `ceph fs status` command to check the file system's state and ensure it has an active MDS.
+      - question: |
+          What does the `ceph fs status` command display?
+        answer: |
+          It displays information about the file system, including its MDS status and overall health.
+      - question: |
+          Why is it important to verify the file system state after recovery?
+        answer: |
+          To ensure the file system is no longer in a degraded state and has an active MDS managing metadata.
+  - context: |
+      Restoring Custom File System Settings
+      -------------------------------------
+
+      After recovering the file system, reapply custom settings such as `standby_count_wanted`, \
+      `required_client_features`,
+      and extra data pools. These settings were lost during FSMap recreation and need to be manually configured.
+
+      Use the `ceph fs set` command to reapply these configurations.
+
+    questions_and_answers:
+      - question: |
+          What happens to custom file system settings during FSMap recreation?
+        answer: |
+          Custom settings such as `standby_count_wanted` and `required_client_features` are lost and must be reapplied.
+      - question: |
+          How can you reapply custom settings to a recovered file system?
+        answer: |
+          Use the `ceph fs set` command to reconfigure custom settings for the file system.
+      - question: |
+          Why is it necessary to restore custom settings after FSMap recreation?
+        answer: |
+          To ensure the file system operates with the desired configuration and performance parameters.
+  - context: |
+      Managing File System Cluster ID (fscid)
+      ---------------------------------------
+
+      The file system cluster ID (fscid) is not preserved during FSMap recreation. This may affect applications like \
+      Ceph CSI, which expect the file system to remain unchanged across recovery.
+
+      To retain the same fscid, specify it during FSMap recreation:
+      ```
+      ceph fs new <fs_name> <metadata_pool> <data_pool> --force --recover --fscid <id>
+      ```
+
+    questions_and_answers:
+      - question: |
+          What happens to the file system cluster ID (fscid) during FSMap recreation?
+        answer: |
+          The fscid is not preserved and may change unless explicitly specified during FSMap recreation.
+      - question: |
+          How can you retain the same fscid during FSMap recreation?
+        answer: |
+          Use the `--fscid <id>` option with the `ceph fs new` command during FSMap recreation.
+      - question: |
+          Why might retaining the same fscid be important?
+        answer: |
+          Some applications, such as Ceph CSI, rely on the file system ID remaining unchanged across recovery.
+document_outline: Guide to Recovering CephFS After Monitor Store Loss
+document:
+  repo: git@github.com:pavankumarag/ceph-instructlab-taxonomy-data.git
+  commit: b60d0d0
+  patterns: [upstream/doc/cephfs/recover-fs-after-mon-store-loss*.md]

--- a/knowledge/technical_manual/Ceph/upstream/Cephfs/scrub/attribution.txt
+++ b/knowledge/technical_manual/Ceph/upstream/Cephfs/scrub/attribution.txt
@@ -1,0 +1,4 @@
+Title of work: Ceph File System Scrub
+Link to work: https://docs.ceph.com/en/squid/cephfs/scrub/
+License of the work: Apache 2.0
+Creators name: Amarnath

--- a/knowledge/technical_manual/Ceph/upstream/Cephfs/scrub/qna.yaml
+++ b/knowledge/technical_manual/Ceph/upstream/Cephfs/scrub/qna.yaml
@@ -1,0 +1,165 @@
+version: 3
+created_by: Amarnath
+domain: opensource_storage
+seed_examples:
+  - context: |
+      Overview of CephFS Scrub
+      ------------------------
+
+      CephFS provides administrators with tools to check and maintain filesystem consistency via scrub commands.
+      Scrubs are categorized into two types:
+      - **Forward Scrub**: Checks consistency from the root (or a subdirectory) and evaluates the filesystem hierarchy.
+      - **Backward Scrub**: Analyzes RADOS objects and maps them back to the filesystem structure.
+
+      All forward scrub commands must be directed to rank 0 of the MDS. Administrators can initiate scrubs for specific
+      paths or the entire filesystem hierarchy.
+    questions_and_answers:
+      - question: |
+          What are the two types of CephFS scrubs?
+        answer: |
+          - Forward Scrub: Ensures consistency by traversing the filesystem hierarchy.
+          - Backward Scrub: Maps RADOS objects back to the filesystem structure.
+      - question: |
+          Where must CephFS forward scrub commands be directed?
+        answer: |
+          Forward scrub commands must be directed to rank 0 of the MDS.
+      - question: |
+          What is the main purpose of CephFS scrubs?
+        answer: |
+          CephFS scrubs ensure the consistency of the filesystem by verifying and repairing metadata and RADOS objects.
+
+  - context: |
+      Initiating File System Scrub
+      ----------------------------
+
+      To start a scrub operation for a directory tree, use the following command:
+
+      ```
+      ceph tell mds.<fsname>:0 scrub start <path> [scrubopts] [tag]
+      ```
+
+      Options for `scrubopts` include `recursive`, `force`, and `repair`. Tags can be custom strings or generated
+      UUIDs. For example:
+
+      ```
+      ceph tell mds.cephfs:0 scrub start / recursive
+      ```
+
+      Scrub operations are asynchronous and tagged for tracking. Use `scrub status` to monitor progress and verify
+      inode scrubbing using extended attributes.
+    questions_and_answers:
+      - question: |
+          What command is used to start a CephFS scrub operation?
+        answer: |
+          Use `ceph tell mds.<fsname>:0 scrub start <path> [scrubopts] [tag]` to start a scrub operation.
+      - question: |
+          What are some options available for `scrubopts` in CephFS scrubs?
+        answer: |
+          Options include `recursive`, `force`, and `repair`.
+      - question: |
+          How can you track the progress of an ongoing scrub operation?
+        answer: |
+          Use the `scrub status` command to monitor the progress of a scrub operation.
+
+  - context: |
+      Monitoring and Controlling Scrubs
+      ---------------------------------
+
+      The status of ongoing scrubs can be monitored using the `scrub status` command. For example:
+
+      ```
+      ceph tell mds.cephfs:0 scrub status
+      ```
+
+      This provides details about active scrubs, including the path and options. Scrubs can also be controlled with
+      the following commands:
+      - `scrub pause`: Pauses ongoing scrubs.
+      - `scrub resume`: Resumes paused scrubs.
+      - `scrub abort`: Aborts ongoing scrubs, removing pending inodes from the queue.
+
+      Example to pause a scrub:
+
+      ```
+      ceph tell mds.cephfs:0 scrub pause
+      ```
+    questions_and_answers:
+      - question: |
+          What command provides the status of ongoing CephFS scrubs?
+        answer: |
+          Use `ceph tell mds.cephfs:0 scrub status` to check the status of ongoing scrubs.
+      - question: |
+          How can you pause an ongoing CephFS scrub operation?
+        answer: |
+          Use the `scrub pause` command to pause an ongoing scrub.
+      - question: |
+          What happens when you abort a CephFS scrub operation?
+        answer: |
+          Aborting removes pending inodes from the scrub queue and stops further operations.
+
+  - context: |
+      Types of Damage Detected by Scrubs
+      ----------------------------------
+
+      CephFS scrubs can identify and repair the following types of damages:
+      - **DENTRY**: Missing inode's directory entry.
+      - **DIR_FRAG**: Missing directory fragments.
+      - **BACKTRACE**: Corrupted backtrace in the data pool.
+
+      To repair damage during a scrub, use:
+
+      ```
+      ceph tell mds.<fsname>:0 scrub start /path recursive, repair, force
+      ```
+
+      Successfully repaired damages are removed from the damage table automatically.
+    questions_and_answers:
+      - question: |
+          What are the three types of damage that CephFS scrubs can detect?
+        answer: |
+          - DENTRY: Missing inode's directory entry.
+          - DIR_FRAG: Missing directory fragments.
+          - BACKTRACE: Corrupted backtrace in the data pool.
+      - question: |
+          How can you initiate a repair during a CephFS scrub?
+        answer: |
+          Use the command `ceph tell mds.<fsname>:0 scrub start /path recursive, repair, force`.
+      - question: |
+          What happens to damages repaired by CephFS scrubs?
+        answer: |
+          Repaired damages are automatically removed from the damage table.
+
+  - context: |
+      Evaluating Strays During Scrubs
+      -------------------------------
+
+      To evaluate and purge stray directories, use:
+
+      ```
+      ceph tell mds.<fsname>:0 scrub start ~mdsdir recursive
+      ```
+
+      By default, stray directories (`~mdsdir`) are not scrubbed during root scrubs. To include them, use:
+
+      ```
+      ceph tell mds.<fsname>:0 scrub start / recursive,scrub_mdsdir
+      ```
+
+      Stray directories are typically used for managing orphaned inodes.
+    questions_and_answers:
+      - question: |
+          How can you evaluate stray directories during a CephFS scrub?
+        answer: |
+          Use the command `ceph tell mds.<fsname>:0 scrub start ~mdsdir recursive`.
+      - question: |
+          Are stray directories included by default in root scrubs?
+        answer: |
+          No, stray directories are not included by default in root scrubs.
+      - question: |
+          What is the purpose of stray directories (`~mdsdir`) in CephFS?
+        answer: |
+          Stray directories are used for managing orphaned inodes.
+document_outline: Guide to managing Ceph File System Scrubs
+document:
+  repo: git@github.com:pavankumarag/ceph-instructlab-taxonomy-data.git
+  commit: b60d0d0
+  patterns: [upstream/doc/cephfs/scrub*.md]


### PR DESCRIPTION
Added qna files for 



1. ceph-taxonomy-and-data-model2/ceph-instructlab-taxonomy-data/upstream/doc/cephfs/recover-fs-after-mon-store-loss.md
2. ceph-taxonomy-and-data-model2/ceph-instructlab-taxonomy-data/upstream/doc/cephfs/scrub.md
3. ceph-taxonomy-and-data-model2/ceph-instructlab-taxonomy-data/upstream/doc/cephfs/mds-journaling.rst
4. ceph-taxonomy-and-data-model2/ceph-instructlab-taxonomy-data/upstream/doc/cephfs/multimds.rst
5. ceph-taxonomy-and-data-model2/ceph-instructlab-taxonomy-data/upstream/doc/cephfs/mds-states.md
6. ceph-taxonomy-and-data-model2/ceph-instructlab-taxonomy-data/upstream/doc/cephfs/nfs.md
7. ceph-taxonomy-and-data-model2/ceph-instructlab-taxonomy-data/upstream/doc/cephfs/mds-config-ref.md
8. ceph-taxonomy-and-data-model2/ceph-instructlab-taxonomy-data/upstream/doc/cephfs/full.md
9. ceph-taxonomy-and-data-model2/ceph-instructlab-taxonomy-data/upstream/doc/cephfs/mdcache.md
10. ceph-taxonomy-and-data-model2/ceph-instructlab-taxonomy-data/upstream/doc/cephfs/mount-using-kernel-driver.md




**Describe the contribution to the taxonomy**

<!-- A concise description of what the contribution brings, replace "..." in the bullet list -->

- ...
- ...
- ...


**Input given at the prompt**

<!-- What you entered, replace "..." -->

```
   ...
```


**Response from the original model**


<!-- What you received from the original model in response to your input, 
replace "..." -->

```
  ...
```


**Response from the fine-tuned model**


<!-- Generate a synthetic dataset based on your newly added seed data; train the model 
with the synthetic data and now re-test the model's response with the same prompt.
Replace "..." with what you receive with the finetuned model. -->

```
  ...
```

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [ ] The contribution was tested with `ilab generate`
- [ ] No errors or warnings were produced by `ilab generate`
- [ ] All [commits are signed off](https://github.com/instructlab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [ ] The `qna.yaml` file contains at least 5 `seed_examples`
- [ ] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
- [ ] An `attribution.txt` file in the same folder as the `qna.yaml` file
- [ ] Content does not include PII or otherwise sensitive or confidential information
- [ ] Content does not include anything documented in the project's [Avoid these Topics](https://github.com/instructlab/taxonomy/blob/main/docs/SKILLS_GUIDE.md#avoid-these-topics) guidelines
